### PR TITLE
Add a formal Public Domain LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>


### PR DESCRIPTION
### What
Add a formal `LICENSE` file containing a common statement to release to the public domain.

### Why
I just discovered `consoledotnottrack.com` and was taking a look to see if there's anyway I could contribute other than [tweeting](https://twitter.com/___leigh___/status/1195233556835889152) about it. On first glance I didn't think it had a license that would allow me to contribute within the freedom of open source. On a second glance I realized the `README.md` contains a statement at the bottom that the code is released into the public domain, but I almost missed it.

It's easy to miss, and without a `LICENSE` file the project doesn't show up with GitHub's heuristics as having a license.

The Unlicense license looks like a great way to release the code into the public domain. GitHub includes it in its set of default licenses to choose from. GitHub states the following about the license:

<img width="568" alt="Screen Shot 2019-11-14 at 11 01 44 PM" src="https://user-images.githubusercontent.com/351529/68923276-c4383a80-0732-11ea-8e21-083e45d9b295.png">
